### PR TITLE
Allow usage of Derived classes and fix some bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.8)
 project(retain-ptr
   VERSION 0.1.0)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if (PYTHONLIBS_FOUND)
   endif()
 endif ()
 
-add_library(doctest-main OBJECT ${TEST_SOURCE_DIR}/doctest.cxx)
+add_library(doctest-main STATIC ${TEST_SOURCE_DIR}/doctest.cxx)
 target_compile_options(doctest-main
   PUBLIC
     $<$<BOOL:${CAN_USE_COVERAGE}>:${USE_COVERAGE}>
@@ -98,16 +98,16 @@ target_compile_options(doctest-main
     $<$<CXX_COMPILER_ID:Clang>:-Wno-weak-vtables>)
 
 if (TARGET pywrap)
-  add_executable(test-python ${TEST_SOURCE_DIR}/python.cxx
-    $<TARGET_OBJECTS:doctest-main>)
+  add_executable(test-python ${TEST_SOURCE_DIR}/python.cxx)
   add_test(python test-python)
-  target_compile_options(test-python
-    PRIVATE
-      $<TARGET_PROPERTY:doctest-main,INTERFACE_COMPILE_OPTIONS>)
   target_include_directories(test-python SYSTEM PRIVATE ${TEST_SOURCE_DIR})
-  target_include_directories(test-python PUBLIC
-    $<TARGET_PROPERTY:pywrap,INTERFACE_INCLUDE_DIRECTORIES>)
-  target_link_libraries(test-python PUBLIC retain-ptr pywrap)
+  target_link_libraries(test-python PUBLIC retain-ptr pywrap doctest-main)
   target_link_libraries(test-python PRIVATE
     $<$<BOOL:${CAN_USE_COVERAGE}>:${USE_COVERAGE}>)
 endif ()
+
+add_executable(test-usage_example ${TEST_SOURCE_DIR}/usage_example.cxx)
+add_test(usage_example test-usage_example)
+target_link_libraries(test-usage_example PUBLIC retain-ptr doctest-main)
+target_link_libraries(test-usage_example PRIVATE
+  $<$<BOOL:${CAN_USE_COVERAGE}>:${USE_COVERAGE}>)

--- a/include/sg14/memory.hpp
+++ b/include/sg14/memory.hpp
@@ -134,7 +134,8 @@ struct retain_traits final {
   template <class U>
   static void decrement (reference_count<U>* ptr) noexcept {
     static_assert(std::is_base_of_v<U, T>, "");
-    if (ptr->count -= 1) { delete static_cast<T*>(ptr); }
+    --ptr->count;
+    if (not use_count(ptr)) { delete static_cast<T*>(ptr); }
   }
   template <class U>
   static long use_count (reference_count<U>* ptr) noexcept {

--- a/include/sg14/memory.hpp
+++ b/include/sg14/memory.hpp
@@ -106,40 +106,36 @@ constexpr adopt_object_t adopt_object { };
 
 template <class T>
 struct retain_traits final {
-
   template <class U>
+  using enable_if_base = std::enable_if_t<std::is_base_of_v<U, T>>;
+
+  template <class U, class = enable_if_base<U>>
   static void increment (atomic_reference_count<U>* ptr) noexcept {
-    static_assert(std::is_base_of_v<U, T>, "");
     ptr->count.fetch_add(1, std::memory_order_relaxed);
   }
 
-  template <class U>
+  template <class U, class = enable_if_base<U>>
   static void decrement (atomic_reference_count<U>* ptr) noexcept {
-    static_assert(std::is_base_of_v<U, T>, "");
     ptr->count.fetch_sub(1, std::memory_order_acq_rel);
     if (not use_count(ptr)) { delete static_cast<T*>(ptr); }
   }
 
-  template <class U>
+  template <class U, class = enable_if_base<U>>
   static long use_count (atomic_reference_count<U>* ptr) noexcept {
-    static_assert(std::is_base_of_v<U, T>, "");
     return ptr->count.load(std::memory_order_relaxed);
   }
 
-  template <class U>
+  template <class U, class = enable_if_base<U>>
   static void increment (reference_count<U>* ptr) noexcept {
-    static_assert(std::is_base_of_v<U, T>, "");
     ++ptr->count;
   }
-  template <class U>
+  template <class U, class = enable_if_base<U>>
   static void decrement (reference_count<U>* ptr) noexcept {
-    static_assert(std::is_base_of_v<U, T>, "");
     --ptr->count;
     if (not use_count(ptr)) { delete static_cast<T*>(ptr); }
   }
-  template <class U>
+  template <class U, class = enable_if_base<U>>
   static long use_count (reference_count<U>* ptr) noexcept {
-    static_assert(std::is_base_of_v<U, T>, "");
     return ptr->count;
   }
 };

--- a/include/sg14/memory.hpp
+++ b/include/sg14/memory.hpp
@@ -82,7 +82,7 @@ template <class> struct retain_traits;
 
 template <class T>
 struct atomic_reference_count {
-  friend retain_traits<T>;
+  template <class> friend class retain_traits;
 protected:
   atomic_reference_count () = default;
 private:
@@ -91,7 +91,7 @@ private:
 
 template <class T>
 struct reference_count {
-  friend retain_traits<T>;
+  template <class> friend class retain_traits;
 protected:
   reference_count () = default;
 private:
@@ -107,24 +107,30 @@ constexpr adopt_object_t adopt_object { };
 template <class T>
 struct retain_traits final {
 
-  static void increment (atomic_reference_count<T>* ptr) noexcept {
-    ptr->count.fetch_add(1, std::memory_order::relaxed);
+  template <class U>
+  static void increment (atomic_reference_count<U>* ptr) noexcept {
+    ptr->count.fetch_add(1, std::memory_order_relaxed);
   }
 
-  static void decrement (atomic_reference_count<T>* ptr) noexcept {
+  template <class U>
+  static void decrement (atomic_reference_count<U>* ptr) noexcept {
     ptr->count.fetch_sub(1, std::memory_order_acq_rel);
     if (not use_count(ptr)) { delete static_cast<T*>(ptr); }
   }
 
-  static long use_count (atomic_reference_count<T>* ptr) noexcept {
-    return ptr->count.load(std::memory_order::relaxed);
+  template <class U>
+  static long use_count (atomic_reference_count<U>* ptr) noexcept {
+    return ptr->count.load(std::memory_order_relaxed);
   }
 
-  static void increment (reference_count<T>* ptr) noexcept { ++ptr->count; }
-  static void decrement (reference_count<T>* ptr) noexcept {
+  template <class U>
+  static void increment (reference_count<U>* ptr) noexcept { ++ptr->count; }
+  template <class U>
+  static void decrement (reference_count<U>* ptr) noexcept {
     if (ptr->count -= 1) { delete static_cast<T*>(ptr); }
   }
-  static long use_count (reference_count<T>* ptr) noexcept {
+  template <class U>
+  static long use_count (reference_count<U>* ptr) noexcept {
     return ptr->count;
   }
 };

--- a/include/sg14/memory.hpp
+++ b/include/sg14/memory.hpp
@@ -211,7 +211,7 @@ struct retain_ptr {
 
   long use_count () const {
     if constexpr (has_use_count) {
-      return this->get() ? traits_type::count(this->get()) : 0;
+      return this->get() ? traits_type::use_count(this->get()) : 0;
     } else { return -1; }
   }
 

--- a/include/sg14/memory.hpp
+++ b/include/sg14/memory.hpp
@@ -109,28 +109,36 @@ struct retain_traits final {
 
   template <class U>
   static void increment (atomic_reference_count<U>* ptr) noexcept {
+    static_assert(std::is_base_of_v<U, T>, "");
     ptr->count.fetch_add(1, std::memory_order_relaxed);
   }
 
   template <class U>
   static void decrement (atomic_reference_count<U>* ptr) noexcept {
+    static_assert(std::is_base_of_v<U, T>, "");
     ptr->count.fetch_sub(1, std::memory_order_acq_rel);
     if (not use_count(ptr)) { delete static_cast<T*>(ptr); }
   }
 
   template <class U>
   static long use_count (atomic_reference_count<U>* ptr) noexcept {
+    static_assert(std::is_base_of_v<U, T>, "");
     return ptr->count.load(std::memory_order_relaxed);
   }
 
   template <class U>
-  static void increment (reference_count<U>* ptr) noexcept { ++ptr->count; }
+  static void increment (reference_count<U>* ptr) noexcept {
+    static_assert(std::is_base_of_v<U, T>, "");
+    ++ptr->count;
+  }
   template <class U>
   static void decrement (reference_count<U>* ptr) noexcept {
+    static_assert(std::is_base_of_v<U, T>, "");
     if (ptr->count -= 1) { delete static_cast<T*>(ptr); }
   }
   template <class U>
   static long use_count (reference_count<U>* ptr) noexcept {
+    static_assert(std::is_base_of_v<U, T>, "");
     return ptr->count;
   }
 };

--- a/tests/usage_example.cxx
+++ b/tests/usage_example.cxx
@@ -1,0 +1,75 @@
+#include "doctest.hpp"
+#include <sg14/memory.hpp>
+
+template<class T>
+struct instance_counted
+{
+  static long numInstances;
+  instance_counted()
+  {
+    numInstances++;
+  }
+  ~instance_counted()
+  {
+    numInstances--;
+  }
+  instance_counted(const instance_counted&)
+  {
+    numInstances++;
+  }
+  instance_counted& operator=(const instance_counted&)
+  {
+    numInstances++;
+  }
+};
+
+template<class T>
+long instance_counted<T>::numInstances = 0;
+
+class Base: public sg14::reference_count<Base>, public instance_counted<Base>
+{};
+
+TEST_CASE("base class")
+{
+  using BasePtr = sg14::retain_ptr<Base>;
+  {
+    BasePtr ptr{new Base};
+    REQUIRE(Base::numInstances == 1);
+    REQUIRE(ptr.use_count() == 1);
+    {
+      BasePtr ptr2{ptr};
+      REQUIRE(Base::numInstances == 1);
+      REQUIRE(ptr.use_count() == 2);
+      BasePtr pt3{std::move(ptr2)};
+      REQUIRE(Base::numInstances == 1);
+      REQUIRE(ptr.use_count() == 2);
+    }
+    REQUIRE(Base::numInstances == 1);
+    REQUIRE(ptr.use_count() == 1);
+  }
+  REQUIRE(Base::numInstances == 0);
+}
+
+class Derived: public Base
+{};
+
+TEST_CASE("derived class")
+{
+  using DerivedPtr = sg14::retain_ptr<Derived>;
+  {
+    DerivedPtr ptr{new Derived};
+    REQUIRE(Derived::numInstances == 1);
+    REQUIRE(ptr.use_count() == 1);
+    {
+      DerivedPtr ptr2{ptr};
+      REQUIRE(Derived::numInstances == 1);
+      REQUIRE(ptr.use_count() == 2);
+      DerivedPtr pt3{std::move(ptr2)};
+      REQUIRE(Derived::numInstances == 1);
+      REQUIRE(ptr.use_count() == 2);
+    }
+    REQUIRE(Derived::numInstances == 1);
+    REQUIRE(ptr.use_count() == 1);
+  }
+  REQUIRE(Derived::numInstances == 0);
+}


### PR DESCRIPTION
This implements what was suggested in #5: Templatize the methods in `retain_traits` so all instances are allowed but restrict the template parameter to base classes of the trait template parameter.

Also:

- Add test to test all 4 scenarios: Base class, Derived class and atomic variants
- Use the correct minimum CMake version (c++17 support added in 3.8) to allow for easier testing
- Refactor the library linking in CMake to avoid code duplication for the new test
- Fix 2 critical bugs preventing this from passing:
  - Wrong name in `use_count` member function
  - Inverted condition of use_count check in `decrement` leading to double-free or access violation